### PR TITLE
Set compiler flags to emit warnings

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,4 +14,4 @@
 %%      limitations under the License.
 %%
 
-{erl_opts, [debug_info]}. 
+{erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.

--- a/src/flame_prof.erl
+++ b/src/flame_prof.erl
@@ -476,10 +476,10 @@ sampler_p_remove(P, #st_r{ps_grps=PsGrps}=S) ->
      end.
 
 sampler_p_add_grp(P, Status, PsGrps, Ps) ->
-    case Ps of
-        #{P:=Grp} -> Grp;
-        #{}       -> Grp = rand:uniform(11)
-    end,
+    Grp = case maps:is_key(P, Ps) of
+              true -> maps:get(P, Ps);
+              false -> rand:uniform(11)
+          end,
     {case PsGrps of
         #{Grp:=#{P:=X}=PsGrp} ->
             {_,Metrics} = X,


### PR DESCRIPTION
The compiler emits warnings about a variable exported from 'case', which might be an issue in environments where the `warnings_as_errors` compiler flag is set.